### PR TITLE
Fix make configs

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -67,9 +67,9 @@ common:
 	# when parsing the file system looking for include paths exclude this for all or
 	# a specific platform
 	ADDON_INCLUDES_EXCLUDE = libs/libaudiodecoder/examples/%
-	ADDON_INCLUDES_EXCLUDE =+ libs/libaudiodecoder/include/%
-	ADDON_INCLUDES_EXCLUDE =+ audiodecodermediafoundation.h
-	ADDON_INCLUDES_EXCLUDE =+ include/audiodecodermediafoundation.h
+	ADDON_INCLUDES_EXCLUDE += libs/libaudiodecoder/include/%
+	ADDON_INCLUDES_EXCLUDE += audiodecodermediafoundation.h
+	ADDON_INCLUDES_EXCLUDE += include/audiodecodermediafoundation.h
 	
 linux64:
 	ADDON_INCLUDES_EXCLUDE += libs/libaudiodecoder/include/audiodecodercoreaudio.h

--- a/example-audioInput/addons.make
+++ b/example-audioInput/addons.make
@@ -1,0 +1,1 @@
+ofxSoundObjects

--- a/example-audioOutput/addons.make
+++ b/example-audioOutput/addons.make
@@ -1,0 +1,1 @@
+ofxSoundObjects

--- a/example-soundMixer/addons.make
+++ b/example-soundMixer/addons.make
@@ -1,0 +1,2 @@
+ofxGui
+ofxSoundObjects

--- a/example-soundObjects/addons.make
+++ b/example-soundObjects/addons.make
@@ -1,0 +1,1 @@
+ofxSoundObjects

--- a/example-soundPlayerObject/addons.make
+++ b/example-soundPlayerObject/addons.make
@@ -1,0 +1,1 @@
+ofxSoundObjects


### PR DESCRIPTION
This adds addons.make to the examples and fixes a little syntactical error in the config file. 