### PR TITLE
fixes for linux

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -72,6 +72,8 @@ common:
     ADDON_INCLUDES_EXCLUDE += libs/libaudiodecoder/include/apple/%
     	
 linux64:
+    ADDON_INCLUDES_EXCLUDE += libs/libaudiodecoder/%
+    ADDON_SOURCES_EXCLUDE += libs/libaudiodecoder/%
 linux:
 msys2:
 

--- a/src/ofxBasicSoundPlayer.cpp
+++ b/src/ofxBasicSoundPlayer.cpp
@@ -37,7 +37,7 @@ ofxBasicSoundPlayer::~ofxBasicSoundPlayer() {
 bool ofxBasicSoundPlayer::load(string filePath, bool _stream){
 	return load(std::filesystem::path(filePath), _stream);
 }
-bool ofxBasicSoundPlayer::load(std::filesystem::path filePath, bool _stream){
+bool ofxBasicSoundPlayer::load(const std::filesystem::path& filePath, bool _stream){
     ofLogVerbose() << "ofxBasicSoundPlayer::load" << endl << "Loading file: " << filePath.string();
 	bIsLoaded = soundFile.load(filePath.string());
 	if(!bIsLoaded) return false;

--- a/src/ofxBasicSoundPlayer.cpp
+++ b/src/ofxBasicSoundPlayer.cpp
@@ -35,7 +35,7 @@ ofxBasicSoundPlayer::~ofxBasicSoundPlayer() {
 }
 
 bool ofxBasicSoundPlayer::load(string filePath, bool _stream){
-    load(std::filesystem::path(filePath), _stream);
+	return load(std::filesystem::path(filePath), _stream);
 }
 bool ofxBasicSoundPlayer::load(std::filesystem::path filePath, bool _stream){
     ofLogVerbose() << "ofxBasicSoundPlayer::load" << endl << "Loading file: " << filePath.string();

--- a/src/ofxBasicSoundPlayer.h
+++ b/src/ofxBasicSoundPlayer.h
@@ -21,8 +21,8 @@ class ofxBasicSoundPlayer: public ofBaseSoundPlayer, public ofxSoundObject {//pu
 public:
 	ofxBasicSoundPlayer();
 	virtual ~ofxBasicSoundPlayer();
-    bool load(string filePath, bool stream = false);
-	bool load(std::filesystem::path filePath, bool stream = false);
+	bool load(std::string filePath, bool stream = false);
+	bool load(const std::filesystem::path& filePath, bool stream = false) override;
 	void unload();
 	void play();
 	void stop();

--- a/src/ofxBasicSoundPlayer.h
+++ b/src/ofxBasicSoundPlayer.h
@@ -23,28 +23,28 @@ public:
 	virtual ~ofxBasicSoundPlayer();
 	bool load(std::string filePath, bool stream = false);
 	bool load(const std::filesystem::path& filePath, bool stream = false) override;
-	void unload();
-	void play();
-	void stop();
+	void unload() override;
+	void play() override;
+	void stop() override;
 
-	void setVolume(float vol);
-	void setPan(float vol); // -1 = left, 1 = right
-	void setSpeed(float spd);
-	void setPaused(bool bP);
-	void setLoop(bool bLp);
-	void setMultiPlay(bool bMp);
-	void setPosition(float pct); // 0 = start, 1 = end;
-	void setPositionMS(int ms);
+	void setVolume(float vol) override;
+	void setPan(float vol) override; // -1 = left, 1 = right
+	void setSpeed(float spd) override;
+	void setPaused(bool bP) override;
+	void setLoop(bool bLp) override;
+	void setMultiPlay(bool bMp) override;
+	void setPosition(float pct) override; // 0 = start, 1 = end;
+	void setPositionMS(int ms) override;
 	
-	float getPosition() const;
-	int getPositionMS() const;
-	bool isPlaying() const;
-	float getSpeed() const;
-	float getPan() const;
-	bool isLoaded() const;
-	float getVolume() const;
+	float getPosition() const override;
+	int getPositionMS() const override;
+	bool isPlaying() const override;
+	float getSpeed() const override;
+	float getPan() const override;
+	bool isLoaded() const override;
+	float getVolume() const override;
 	bool getIsLooping() const;
-	unsigned long getDurationMS();
+	unsigned long getDurationMS() ;
 
 	ofSoundBuffer & getCurrentBuffer();
 

--- a/src/ofxSoundFile.cpp
+++ b/src/ofxSoundFile.cpp
@@ -204,6 +204,7 @@ bool ofxSoundFile::mpg123Open(string path){
 	mpg123_seek(mp3File,0,SEEK_SET);
     
     bitDepth = 16; //TODO:get real bitdepth;.
+	return true;
 }
 #endif
 
@@ -235,6 +236,7 @@ bool ofxSoundFile::sfOpen(string path){
 	samples = sfInfo.frames;
 	samplerate = sfInfo.samplerate;
     bitDepth = 16; //fix
+	return true;
 }
 #endif
 


### PR DESCRIPTION
* exclude libaudioencoder paths from compilation on linux through addon_config
* add missing return statements for some `bool` methods.