### PR TITLE
bug fix: Now changing playback speed of ofxSoundPlayerObject works fine.

### DIFF
--- a/src/ofxSoundPlayerObject.cpp
+++ b/src/ofxSoundPlayerObject.cpp
@@ -367,11 +367,11 @@ void ofxSoundPlayerObject::updatePositions(int nFrames){
 		}
 		for (auto& i : instances){
 			if(i.bIsPlaying){
-				i.position += nFrames;
 				if(i.bUsePreprocessedBuffer){
 					nf = i.preprocessedBuffer.getNumFrames();
+                    i.position += nFrames;
 				}else{
-					i.position *=i.relativeSpeed;
+					i.position += i.relativeSpeed * nFrames;
 				}
 				 
 				if (i.loop) {


### PR DESCRIPTION
As "example-soundPlayerObject" didn't work fine with changing playback speed, I've debugged ofxSoundPlayerObject class.