### PR TITLE
bug fixed: matching channels of ofxSoundRecorderObject

### DIFF
--- a/src/ofxSoundRecorderObject.cpp
+++ b/src/ofxSoundRecorderObject.cpp
@@ -83,14 +83,42 @@ void ofxSoundRecorderObject::threadedFunction(){
 }
 #endif
 //--------------------------------------------------------------
+void ofxSoundRecorderObject::audioOut(ofSoundBuffer &output){
+    if(ofxSoundUtils::checkBuffers(output, getBuffer(), false))
+    {
+        auto& buffer = getBuffer();
+        ofxSoundInput* obj = (ofxSoundInput*)getSignalSourceObject();
+        int buffer_size = obj->getInputStream()->getBufferSize() * obj->getInputStream()->getNumInputChannels();
+        buffer.resize(buffer_size);
+        buffer.setNumChannels(obj->getInputStream()->getNumInputChannels());
+        buffer.setSampleRate(obj->getInputStream()->getSampleRate());
+    }
+    if(inputObject != NULL)
+    {
+        if(isBypassed())
+        {
+            inputObject->audioOut(output);
+        }
+        else
+        {
+            inputObject->audioOut(getBuffer());
+        }
+    }
+    if(!isBypassed())
+    {
+        process(getBuffer(), output);
+    }
+}
+
+//--------------------------------------------------------------
 void ofxSoundRecorderObject::process(ofSoundBuffer &input, ofSoundBuffer &output){
-	input.copyTo(output);
+    input.copyTo(output, output.getNumFrames(), output.getNumChannels(), 0);
 #ifdef OFX_SOUND_ENABLE_THREADED_RECORDER
-	if(recState != IDLE){
-		writeChannel.send(input);
-	}
+    if(recState != IDLE){
+        writeChannel.send(input);
+    }
 #else
-	write(input);
+    write(input);
 #endif
 }
 //--------------------------------------------------------------

--- a/src/ofxSoundRecorderObject.h
+++ b/src/ofxSoundRecorderObject.h
@@ -22,6 +22,7 @@ public:
 #ifdef OFX_SOUND_ENABLE_THREADED_RECORDER
 	virtual ~ofxSoundRecorderObject();
 #endif
+    virtual void audioOut(ofSoundBuffer &output) override;
 	virtual void process(ofSoundBuffer &input, ofSoundBuffer &output) override;
 	
 	


### PR DESCRIPTION
Fixed a bug when ofxSoundRecorderObject can't record properly when the number of input channels and output channels are not the same.

Closes #55